### PR TITLE
fix: make in-place GNU sed compatible

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -eo pipefail
 
-sed -i '' "s/__PHTN_VERSION__/$1/; s/__PHTN_PUBLISHED__/$2/" dist/*.css
+sed -i='' "s/__PHTN_VERSION__/$1/; s/__PHTN_PUBLISHED__/$2/" dist/*.css
 


### PR DESCRIPTION
Silly GNU sed:

```shell
sed: can't read s/__PHTN_VERSION__/1.1.1/; s/__PHTN_PUBLISHED__/1550482267143/: No such file or directory
```

– https://travis-ci.org/swashcap/phtn/builds/494792634

The `-i=''` with the equals seems to fix it for both BSD and GNU sed.